### PR TITLE
Added missing <memory> include

### DIFF
--- a/projects/biogears/libBiogears/include/biogears/engine/Systems/Diffusion.h
+++ b/projects/biogears/libBiogears/include/biogears/engine/Systems/Diffusion.h
@@ -16,6 +16,8 @@ specific language governing permissions and limitations under the License.
 
 #include <Eigen/Core>
 
+#include <memory>
+
 namespace biogears {
 class MassUnit;
 class BioGears;


### PR DESCRIPTION
I'm getting error when compiling by [instructions](https://github.com/BioGearsEngine/core/wiki/Using-Ubuntu-package-system):
```
[4/10] Building CXX object projects/biogears/CMakeFiles/libbiogears.dir/libBiogears/src/engine/Systems/Diffusion.cpp.o
FAILED: projects/biogears/CMakeFiles/libbiogears.dir/libBiogears/src/engine/Systems/Diffusion.cpp.o 
/usr/bin/c++  -DBIOGEARS_COMMON_BUILD_STATIC -DBIOGEARS_THROW_NAN_EXCEPTIONS -DBIOGEARS_THROW_READONLY_EXCEPTIONS -Dbiogears_EXPORTS -I../projects/biogears/libBiogears/include -I../projects/biogears/libBiogears/src -Iprojects/biogears -Iprojects/biogears-common -I../projects/biogears-common/include -I../projects/biogears/libCDM/include -isystem /usr/include/eigen3 -O3 -DNDEBUG -fPIC   -std=gnu++14 -MD -MT projects/biogears/CMakeFiles/libbiogears.dir/libBiogears/src/engine/Systems/Diffusion.cpp.o -MF projects/biogears/CMakeFiles/libbiogears.dir/libBiogears/src/engine/Systems/Diffusion.cpp.o.d -o projects/biogears/CMakeFiles/libbiogears.dir/libBiogears/src/engine/Systems/Diffusion.cpp.o -c ../projects/biogears/libBiogears/src/engine/Systems/Diffusion.cpp
In file included from ../projects/biogears/libBiogears/src/engine/Systems/Diffusion.cpp:12:0:
../projects/biogears/libBiogears/include/biogears/engine/Systems/Diffusion.h:32:49: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   static auto make_unique(BioGears& bg) -> std::unique_ptr<DiffusionCalculator>;
                                                 ^~~~~~~~~~
../projects/biogears/libBiogears/include/biogears/engine/Systems/Diffusion.h:32:49: error: expected ‘;’ at end of member declaration
../projects/biogears/libBiogears/include/biogears/engine/Systems/Diffusion.h:32:59: error: expected unqualified-id before ‘<’ token
   static auto make_unique(BioGears& bg) -> std::unique_ptr<DiffusionCalculator>;
                                                           ^
../projects/biogears/libBiogears/src/engine/Systems/Diffusion.cpp:21:61: error: no ‘std::unique_ptr<biogears::DiffusionCalculator> biogears::DiffusionCalculator::make_unique(biogears::BioGears&)’ member function declared in class ‘biogears::DiffusionCalculator’
 auto DiffusionCalculator::make_unique(BioGears& bg) -> std::unique_ptr<DiffusionCalculator>
                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[7/10] Building CXX object projects/biogears/CMakeFiles/libbiogears.dir/libBiogears/src/engine/Systems/Respiratory.cpp.o
ninja: build stopped: subcommand failed.
```
It looks like we just need `#include <memory>`. Added this include