### PR TITLE
F/abaird pneumo fixes

### DIFF
--- a/projects/biogears/libBiogears/include/biogears/cdm/patient/actions/SEChestTube.h
+++ b/projects/biogears/libBiogears/include/biogears/cdm/patient/actions/SEChestTube.h
@@ -14,8 +14,6 @@ specific language governing permissions and limitations under the License.
 #include <biogears/cdm/patient/actions/SEPatientAction.h>
 #include <biogears/cdm/enums/SEPatientActionsEnums.h>
 
-#include <biogears/schema/cdm/PatientActions.hxx>
-
 #include <random>
 
 namespace biogears {
@@ -33,14 +31,11 @@ public:
   static constexpr const char* TypeTag() { return "SEChestTube"; };
   const char* classname() const override { return TypeTag(); }
 
-  virtual void Clear() override; // clear memory
+  virtual void Invalidate() override; //clear memory
 
   virtual bool IsValid() const override;
   virtual bool IsActive() const override;
   virtual void SetActive(bool b);
-
-  virtual bool Load(const CDM::ChestTubeData& in, std::default_random_engine* rd = nullptr);
-  virtual CDM::ChestTubeData* Unload() const override;
 
   virtual SESide GetSide() const;
   virtual void SetSide(SESide LeftOrRight);
@@ -51,9 +46,6 @@ public:
 
   bool operator==(const SEChestTube& rhs) const;
   bool operator!=(const SEChestTube& rhs) const;
-
-protected:
-  virtual void Unload(CDM::ChestTubeData& data) const;
 
 protected:
   SESide m_Side;

--- a/projects/biogears/libBiogears/include/biogears/cdm/patient/actions/SEChestTube.h
+++ b/projects/biogears/libBiogears/include/biogears/cdm/patient/actions/SEChestTube.h
@@ -1,0 +1,62 @@
+/**************************************************************************************
+Copyright 2015 Applied Research Associates, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the License
+at:
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+**************************************************************************************/
+
+#pragma once
+#include <biogears/cdm/patient/actions/SEPatientAction.h>
+#include <biogears/cdm/enums/SEPatientActionsEnums.h>
+
+#include <biogears/schema/cdm/PatientActions.hxx>
+
+#include <random>
+
+namespace biogears {
+namespace io {
+  class PatientActions;
+}
+
+class BIOGEARS_API SEChestTube : public SEPatientAction {
+  friend io::PatientActions;
+
+public:
+  SEChestTube();
+  virtual ~SEChestTube() override;
+
+  static constexpr const char* TypeTag() { return "SEChestTube"; };
+  const char* classname() const override { return TypeTag(); }
+
+  virtual void Clear() override; // clear memory
+
+  virtual bool IsValid() const override;
+  virtual bool IsActive() const override;
+  virtual void SetActive(bool b);
+
+  virtual bool Load(const CDM::ChestTubeData& in, std::default_random_engine* rd = nullptr);
+  virtual CDM::ChestTubeData* Unload() const override;
+
+  virtual SESide GetSide() const;
+  virtual void SetSide(SESide LeftOrRight);
+  virtual bool HasSide() const;
+  virtual void InvalidateSide();
+
+  virtual void ToString(std::ostream& str) const override;
+
+  bool operator==(const SEChestTube& rhs) const;
+  bool operator!=(const SEChestTube& rhs) const;
+
+protected:
+  virtual void Unload(CDM::ChestTubeData& data) const;
+
+protected:
+  SESide m_Side;
+  SEOnOff m_State;
+};
+}

--- a/projects/biogears/libBiogears/include/biogears/cdm/scenario/SEPatientActionCollection.h
+++ b/projects/biogears/libBiogears/include/biogears/cdm/scenario/SEPatientActionCollection.h
@@ -27,6 +27,7 @@ specific language governing permissions and limitations under the License.
 #include <biogears/cdm/patient/actions/SEChestCompressionForce.h>
 #include <biogears/cdm/patient/actions/SEChestCompressionForceScale.h>
 #include <biogears/cdm/patient/actions/SEChestOcclusiveDressing.h>
+#include <biogears/cdm/patient/actions/SEChestTube.h>
 #include <biogears/cdm/patient/actions/SEConsciousRespiration.h>
 #include <biogears/cdm/patient/actions/SEConsumeNutrients.h>
 #include <biogears/cdm/patient/actions/SEEscharotomy.h>
@@ -274,6 +275,14 @@ public:
   SEChestOcclusiveDressing* GetRightChestOcclusiveDressing() const;
   void RemoveRightChestOcclusiveDressing();
 
+  bool HasChestTube() const;
+  bool HasLeftChestTube() const;
+  SEChestTube* GetLeftChestTube() const;
+  void RemoveLeftChestTube();
+  bool HasRightChestTube() const;
+  SEChestTube* GetRightChestTube() const;
+  void RemoveRightChestTube();
+
   bool HasConsciousRespiration() const;
   SEConsciousRespiration* GetConsciousRespiration() const;
   void RemoveConsciousRespiration();
@@ -422,6 +431,8 @@ protected:
   SEChestCompression* m_ChestCompression;
   SEChestOcclusiveDressing* m_LeftChestOcclusiveDressing;
   SEChestOcclusiveDressing* m_RightChestOcclusiveDressing;
+  SEChestTube* m_LeftChestTube;
+  SEChestTube* m_RightChestTube;
   SEConsciousRespiration* m_ConsciousRespiration;
   SEConsumeNutrients* m_ConsumeNutrients;
   SEEbola* m_Ebola;

--- a/projects/biogears/libBiogears/include/biogears/engine/Systems/Respiratory.h
+++ b/projects/biogears/libBiogears/include/biogears/engine/Systems/Respiratory.h
@@ -130,6 +130,7 @@ private:
   void DoRightNeedleDecompression(double dFlowResistance);
   void DoLeftChestTube(double ctFlowResistance);
   void DoRightChestTube(double ctFlowResistance);
+  void AdjustPleuralCavity();
   // Aerosol Deposition and various Effects
   void ProcessAerosolSubstances();
 
@@ -226,6 +227,7 @@ private:
   SEGasCompartment* m_RightLung;
   SEGasCompartment* m_Lungs;
   SEGasCompartment* m_Trachea;
+  SEGasCompartment* m_pleuralCavity;
   SEGasSubstanceQuantity* m_TracheaO2;
   SEGasSubstanceQuantity* m_TracheaCO2;
   SELiquidSubstanceQuantity* m_AortaO2;

--- a/projects/biogears/libBiogears/include/biogears/engine/Systems/Respiratory.h
+++ b/projects/biogears/libBiogears/include/biogears/engine/Systems/Respiratory.h
@@ -128,6 +128,8 @@ private:
   // Pneumothorax
   void DoLeftNeedleDecompression(double dFlowResistance);
   void DoRightNeedleDecompression(double dFlowResistance);
+  void DoLeftChestTube(double ctFlowResistance);
+  void DoRightChestTube(double ctFlowResistance);
   // Aerosol Deposition and various Effects
   void ProcessAerosolSubstances();
 

--- a/projects/biogears/libBiogears/src/cdm/patient/actions/SEChestTube.cpp
+++ b/projects/biogears/libBiogears/src/cdm/patient/actions/SEChestTube.cpp
@@ -1,0 +1,112 @@
+/**************************************************************************************
+Copyright 2015 Applied Research Associates, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the License
+at:
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+**************************************************************************************/
+
+#include <biogears/cdm/patient/actions/SEChestTube.h>
+
+#include "io/cdm/PatientActions.h"
+namespace biogears {
+SEChestTube::SEChestTube()
+  : SEPatientAction()
+{
+  m_State = SEOnOff::Off;
+  m_Side = SESide::Invalid;
+}
+//-------------------------------------------------------------------------------
+SEChestTube::~SEChestTube()
+{
+  Clear();
+}
+//-------------------------------------------------------------------------------
+void SEChestTube::Clear()
+{
+  SEPatientAction::Clear();
+  m_State = SEOnOff::Off;
+  m_Side = SESide::Invalid;
+}
+//-------------------------------------------------------------------------------
+bool SEChestTube::IsValid() const
+{
+  return SEPatientAction::IsValid() && HasSide();
+}
+//-------------------------------------------------------------------------------
+bool SEChestTube::IsActive() const
+{
+  return IsValid() && m_State == SEOnOff::On;
+}
+//-------------------------------------------------------------------------------
+void SEChestTube::SetActive(bool b)
+{
+  m_State = b ? SEOnOff::On : SEOnOff::Off;
+}
+//-------------------------------------------------------------------------------
+bool SEChestTube::Load(const CDM::ChestTubeData& in, std::default_random_engine* rd)
+{
+  io::PatientActions::UnMarshall(in, *this, rd);
+  return true;
+}
+//-------------------------------------------------------------------------------
+CDM::ChestTubeData* SEChestTube::Unload() const
+{
+  CDM::ChestTubeData* data(new CDM::ChestTubeData());
+  Unload(*data);
+  return data;
+}
+//-------------------------------------------------------------------------------
+void SEChestTube::Unload(CDM::ChestTubeData& data) const
+{
+  io::PatientActions::Marshall(*this, data);
+}
+//-------------------------------------------------------------------------------
+SESide SEChestTube::GetSide() const
+{
+  return m_Side;
+}
+//-------------------------------------------------------------------------------
+void SEChestTube::SetSide(SESide Side)
+{
+  m_Side = Side;
+}
+//-------------------------------------------------------------------------------
+bool SEChestTube::HasSide() const
+{
+  return m_Side == SESide::Invalid ? false : true;
+}
+//-------------------------------------------------------------------------------
+void SEChestTube::InvalidateSide()
+{
+  m_Side = SESide::Invalid;
+}
+//-------------------------------------------------------------------------------
+void SEChestTube::ToString(std::ostream& str) const
+{
+  str << "Patient Action : Needle Decompression";
+  if (HasComment())
+    str << "\n\tComment: " << m_Comment;
+  str << "\n\tState: " << IsActive();
+  str << "\n\tSide: ";
+  HasSide() ? str << GetSide() : str << "No Side Set";
+  str << std::flush;
+}
+//-------------------------------------------------------------------------------
+bool SEChestTube::operator==(const SEChestTube& rhs) const
+{
+  bool equivilant = m_Comment == rhs.m_Comment;
+  equivilant &= m_Side == rhs.m_Side;
+  equivilant &= m_State == rhs.m_State;
+  return equivilant;
+}
+//-------------------------------------------------------------------------------
+bool SEChestTube::operator!=(const SEChestTube& rhs) const
+{
+  return !(*this == rhs);
+}
+}

--- a/projects/biogears/libBiogears/src/cdm/patient/actions/SEChestTube.cpp
+++ b/projects/biogears/libBiogears/src/cdm/patient/actions/SEChestTube.cpp
@@ -88,7 +88,7 @@ void SEChestTube::InvalidateSide()
 //-------------------------------------------------------------------------------
 void SEChestTube::ToString(std::ostream& str) const
 {
-  str << "Patient Action : Needle Decompression";
+  str << "Patient Action : Chest Tube";
   if (HasComment())
     str << "\n\tComment: " << m_Comment;
   str << "\n\tState: " << IsActive();

--- a/projects/biogears/libBiogears/src/cdm/patient/actions/SEChestTube.cpp
+++ b/projects/biogears/libBiogears/src/cdm/patient/actions/SEChestTube.cpp
@@ -23,12 +23,12 @@ SEChestTube::SEChestTube()
 //-------------------------------------------------------------------------------
 SEChestTube::~SEChestTube()
 {
-  Clear();
+  Invalidate();
 }
 //-------------------------------------------------------------------------------
-void SEChestTube::Clear()
+void SEChestTube::Invalidate()
 {
-  SEPatientAction::Clear();
+  SEPatientAction::Invalidate();
   m_State = SEOnOff::Off;
   m_Side = SESide::Invalid;
 }
@@ -46,24 +46,6 @@ bool SEChestTube::IsActive() const
 void SEChestTube::SetActive(bool b)
 {
   m_State = b ? SEOnOff::On : SEOnOff::Off;
-}
-//-------------------------------------------------------------------------------
-bool SEChestTube::Load(const CDM::ChestTubeData& in, std::default_random_engine* rd)
-{
-  io::PatientActions::UnMarshall(in, *this, rd);
-  return true;
-}
-//-------------------------------------------------------------------------------
-CDM::ChestTubeData* SEChestTube::Unload() const
-{
-  CDM::ChestTubeData* data(new CDM::ChestTubeData());
-  Unload(*data);
-  return data;
-}
-//-------------------------------------------------------------------------------
-void SEChestTube::Unload(CDM::ChestTubeData& data) const
-{
-  io::PatientActions::Marshall(*this, data);
 }
 //-------------------------------------------------------------------------------
 SESide SEChestTube::GetSide() const

--- a/projects/biogears/libBiogears/src/cdm/scenario/SEPatientActionCollection.cpp
+++ b/projects/biogears/libBiogears/src/cdm/scenario/SEPatientActionCollection.cpp
@@ -281,6 +281,8 @@ SEPatientActionCollection::SEPatientActionCollection(SESubstanceManager& substan
   m_BurnWound = nullptr;
   m_CardiacArrest = nullptr;
   m_ChestCompression = nullptr;
+  m_LeftChestTube = nullptr;
+  m_RightChestTube = nullptr;
   m_ConsciousRespiration = nullptr;
   m_ConsumeNutrients = nullptr;
   m_LeftChestOcclusiveDressing = nullptr;
@@ -322,6 +324,8 @@ void SEPatientActionCollection::Invalidate()
   RemoveBronchoconstriction();
   RemoveBurnWound();
   RemoveChestCompression();
+  RemoveLeftChestTube();
+  RemoveRightChestTube();
   RemoveCardiacArrest();
   RemoveConsciousRespiration();
   RemoveConsumeNutrients();
@@ -346,14 +350,158 @@ void SEPatientActionCollection::Invalidate()
   RemoveUrinate();
   RemoveOverride();
 
-  DELETE_MAP_OF_POINTERS(m_Escharotomies);
-  DELETE_MAP_OF_POINTERS(m_Hemorrhages);
-  DELETE_MAP_OF_POINTERS(m_PainStimuli);
-  DELETE_MAP_OF_POINTERS(m_SubstanceBolus);
-  DELETE_MAP_OF_POINTERS(m_SubstanceInfusions);
-  DELETE_MAP_OF_POINTERS(m_SubstanceOralDoses);
-  DELETE_MAP_OF_POINTERS(m_SubstanceCompoundInfusions);
-  DELETE_MAP_OF_POINTERS(m_Tourniquets);
+  DELETE_MAP_SECOND(m_Escharotomies);
+  DELETE_MAP_SECOND(m_Hemorrhages);
+  DELETE_MAP_SECOND(m_PainStimuli);
+  DELETE_MAP_SECOND(m_SubstanceBolus);
+  DELETE_MAP_SECOND(m_SubstanceInfusions);
+  DELETE_MAP_SECOND(m_SubstanceOralDoses);
+  DELETE_MAP_SECOND(m_SubstanceCompoundInfusions);
+  DELETE_MAP_SECOND(m_Tourniquets);
+}
+//-------------------------------------------------------------------------------
+void SEPatientActionCollection::Unload(std::vector<CDM::ActionData*>& to)
+{
+  if (HasAcuteRespiratoryDistress()) {
+    to.push_back(GetAcuteRespiratoryDistress()->Unload());
+  }
+  if (HasAcuteStress()) {
+    to.push_back(GetAcuteStress()->Unload());
+  }
+  if (HasExampleAction()) {
+    to.push_back(GetExampleAction()->Unload());
+  }
+  if (HasAirwayObstruction()) {
+    to.push_back(GetAirwayObstruction()->Unload());
+  }
+  if (HasApnea()) {
+    to.push_back(GetApnea()->Unload());
+  }
+  if (HasAsthmaAttack()) {
+    to.push_back(GetAsthmaAttack()->Unload());
+  }
+  if (HasBrainInjury()) {
+    to.push_back(GetBrainInjury()->Unload());
+  }
+  if (HasBronchoconstriction()) {
+    to.push_back(GetBronchoconstriction()->Unload());
+  }
+  if (HasBurnWound()) {
+    to.push_back(GetBurnWound()->Unload());
+  }
+  if (HasCardiacArrest()) {
+    to.push_back(GetCardiacArrest()->Unload());
+  }
+  if (HasChestCompressionForce()) {
+    to.push_back(GetChestCompressionForce()->Unload());
+  }
+  if (HasChestCompressionForceScale()) {
+    to.push_back(GetChestCompressionForceScale()->Unload());
+  }
+  if (HasLeftChestOcclusiveDressing()) {
+    to.push_back(GetLeftChestOcclusiveDressing()->Unload());
+  }
+  if (HasRightChestOcclusiveDressing()) {
+    to.push_back(GetRightChestOcclusiveDressing()->Unload());
+  }
+  if (HasLeftChestTube()) {
+    to.push_back(GetLeftChestTube()->Unload());
+  }
+  if (HasRightChestTube()) {
+    to.push_back(GetRightChestTube()->Unload());
+  }
+  if (HasConsciousRespiration()) {
+    to.push_back(GetConsciousRespiration()->Unload());
+  }
+  if (HasConsumeNutrients()) {
+    to.push_back(GetConsumeNutrients()->Unload());
+  }
+  if (HasEscharotomy()) {
+    for (auto itr : GetEscharotomies()) {
+      to.push_back(itr.second->Unload());
+    }
+  }
+  if (HasEbola()) {
+    to.push_back(GetEbola()->Unload());
+  }
+  if (HasExercise()) {
+    to.push_back(GetExercise()->Unload());
+  }
+  if (HasHemorrhage()) {
+    for (auto itr : GetHemorrhages()) {
+      to.push_back(itr.second->Unload());
+    }
+  }
+  if (HasInfection()) {
+    to.push_back(GetInfection()->Unload());
+  }
+  if (HasIntubation()) {
+    to.push_back(GetIntubation()->Unload());
+  }
+  if (HasMechanicalVentilation()) {
+    to.push_back(GetMechanicalVentilation()->Unload());
+  }
+  if (HasNasalCannula()) {
+    to.push_back(GetNasalCannula()->Unload());
+  }
+  if (HasLeftNeedleDecompression()) {
+    to.push_back(GetLeftNeedleDecompression()->Unload());
+  }
+  if (HasRightNeedleDecompression()) {
+    to.push_back(GetRightNeedleDecompression()->Unload());
+  }
+  if (HasPainStimulus()) {
+    for (auto itr : GetPainStimuli()) {
+      to.push_back(itr.second->Unload());
+    }
+  }
+  if (HasPericardialEffusion()) {
+    to.push_back(GetPericardialEffusion()->Unload());
+  }
+  if (HasPulmonaryShunt()) {
+    to.push_back(GetPulmonaryShunt()->Unload());
+  }
+  if (HasRadiationAbsorbedDose()) {
+    to.push_back(GetRadiationAbsorbedDose()->Unload());
+  }
+  if (HasSleepState()) {
+    to.push_back(GetSleepState()->Unload());
+  }
+  if (HasLeftClosedTensionPneumothorax()) {
+    to.push_back(GetLeftClosedTensionPneumothorax()->Unload());
+  }
+  if (HasLeftOpenTensionPneumothorax()) {
+    to.push_back(GetLeftOpenTensionPneumothorax()->Unload());
+  }
+  if (HasRightClosedTensionPneumothorax()) {
+    to.push_back(GetRightClosedTensionPneumothorax()->Unload());
+  }
+  if (HasRightOpenTensionPneumothorax()) {
+    to.push_back(GetRightOpenTensionPneumothorax()->Unload());
+  }
+  for (auto itr : GetSubstanceBoluses()) {
+    to.push_back(itr.second->Unload());
+  }
+  for (auto itr : GetSubstanceInfusions()) {
+    to.push_back(itr.second->Unload());
+  }
+  for (auto itr : GetSubstanceOralDoses()) {
+    to.push_back(itr.second->Unload());
+  }
+  for (auto itr : GetSubstanceCompoundInfusions()) {
+    to.push_back(itr.second->Unload());
+  }
+  if (HasTourniquet()) {
+    for (auto itr : GetTourniquets()) {
+      to.push_back(itr.second->Unload());
+    }
+  }
+  if (HasUrinate()) {
+    to.push_back(GetUrinate()->Unload());
+  }
+  if (HasOverride()) {
+    to.push_back((GetOverride()->Unload()));
+  }
 }
 //-------------------------------------------------------------------------------
 bool SEPatientActionCollection::ProcessAction(const SEPatientAction& action, const PhysiologyEngine& engine)
@@ -574,6 +722,31 @@ bool SEPatientActionCollection::ProcessAction(const SEPatientAction& action, con
         return true;
       }
       return IsValid(*m_RightChestOcclusiveDressing);
+    }
+  }
+
+  auto chestTube = dynamic_cast<const SEChestTube*>(&action);
+  if (chestTube != nullptr) {
+    if (chestTube->Side() == SESide::Left) {
+      if (m_LeftChestTube == nullptr) {
+        m_LeftChestTube = new SEChestTube();
+      }
+      m_LeftChestTube->Load(*chestTube);
+      if (!m_LeftChestTube->IsActive()) {
+        RemoveLeftChestTube();
+        return true;
+      }
+      return IsValid(*m_LeftChestTube);
+    } else if (chestTube->Side() == SESide::Right) {
+      if (m_RightChestTube == nullptr) {
+        m_RightChestTube = new SEChestTube();
+      }
+      m_RightChestTube->Load(*chestTube);
+      if (!m_RightChestTube->IsActive()) {
+        RemoveRightChestTube();
+        return true;
+      }
+      return IsValid(*m_RightChestTube);
     }
   }
 
@@ -1163,6 +1336,41 @@ SEChestOcclusiveDressing* SEPatientActionCollection::GetRightChestOcclusiveDress
 void SEPatientActionCollection::RemoveRightChestOcclusiveDressing()
 {
   SAFE_DELETE(m_RightChestOcclusiveDressing);
+}
+//-------------------------------------------------------------------------------
+bool SEPatientActionCollection::HasChestTube() const
+{
+  return m_LeftChestTube != nullptr || m_RightChestTube != nullptr ? true : false;
+}
+//-------------------------------------------------------------------------------
+bool SEPatientActionCollection::HasLeftChestTube() const
+{
+  return m_LeftChestTube != nullptr ? true : false;
+}
+//-------------------------------------------------------------------------------
+SEChestTube* SEPatientActionCollection::GetLeftChestTube() const
+{
+  return m_LeftChestTube;
+}
+//-------------------------------------------------------------------------------
+void SEPatientActionCollection::RemoveLeftChestTube()
+{
+  SAFE_DELETE(m_LeftChestTube);
+}
+//-------------------------------------------------------------------------------
+bool SEPatientActionCollection::HasRightChestTube() const
+{
+  return m_RightChestTube != nullptr ? true : false;
+}
+//-------------------------------------------------------------------------------
+SEChestTube* SEPatientActionCollection::GetRightChestTube() const
+{
+  return m_RightChestTube;
+}
+//-------------------------------------------------------------------------------
+void SEPatientActionCollection::RemoveRightChestTube()
+{
+  SAFE_DELETE(m_RightChestTube);
 }
 //-------------------------------------------------------------------------------
 bool SEPatientActionCollection::HasConsciousRespiration() const

--- a/projects/biogears/libBiogears/src/cdm/scenario/SEPatientActionCollection.cpp
+++ b/projects/biogears/libBiogears/src/cdm/scenario/SEPatientActionCollection.cpp
@@ -331,6 +331,8 @@ void SEPatientActionCollection::Invalidate()
   RemoveConsumeNutrients();
   RemoveLeftChestOcclusiveDressing();
   RemoveRightChestOcclusiveDressing();
+  RemoveLeftChestTube();
+  RemoveRightChestTube();
   RemoveExercise();
   RemoveEbola();
   RemoveInfection();
@@ -350,158 +352,14 @@ void SEPatientActionCollection::Invalidate()
   RemoveUrinate();
   RemoveOverride();
 
-  DELETE_MAP_SECOND(m_Escharotomies);
-  DELETE_MAP_SECOND(m_Hemorrhages);
-  DELETE_MAP_SECOND(m_PainStimuli);
-  DELETE_MAP_SECOND(m_SubstanceBolus);
-  DELETE_MAP_SECOND(m_SubstanceInfusions);
-  DELETE_MAP_SECOND(m_SubstanceOralDoses);
-  DELETE_MAP_SECOND(m_SubstanceCompoundInfusions);
-  DELETE_MAP_SECOND(m_Tourniquets);
-}
-//-------------------------------------------------------------------------------
-void SEPatientActionCollection::Unload(std::vector<CDM::ActionData*>& to)
-{
-  if (HasAcuteRespiratoryDistress()) {
-    to.push_back(GetAcuteRespiratoryDistress()->Unload());
-  }
-  if (HasAcuteStress()) {
-    to.push_back(GetAcuteStress()->Unload());
-  }
-  if (HasExampleAction()) {
-    to.push_back(GetExampleAction()->Unload());
-  }
-  if (HasAirwayObstruction()) {
-    to.push_back(GetAirwayObstruction()->Unload());
-  }
-  if (HasApnea()) {
-    to.push_back(GetApnea()->Unload());
-  }
-  if (HasAsthmaAttack()) {
-    to.push_back(GetAsthmaAttack()->Unload());
-  }
-  if (HasBrainInjury()) {
-    to.push_back(GetBrainInjury()->Unload());
-  }
-  if (HasBronchoconstriction()) {
-    to.push_back(GetBronchoconstriction()->Unload());
-  }
-  if (HasBurnWound()) {
-    to.push_back(GetBurnWound()->Unload());
-  }
-  if (HasCardiacArrest()) {
-    to.push_back(GetCardiacArrest()->Unload());
-  }
-  if (HasChestCompressionForce()) {
-    to.push_back(GetChestCompressionForce()->Unload());
-  }
-  if (HasChestCompressionForceScale()) {
-    to.push_back(GetChestCompressionForceScale()->Unload());
-  }
-  if (HasLeftChestOcclusiveDressing()) {
-    to.push_back(GetLeftChestOcclusiveDressing()->Unload());
-  }
-  if (HasRightChestOcclusiveDressing()) {
-    to.push_back(GetRightChestOcclusiveDressing()->Unload());
-  }
-  if (HasLeftChestTube()) {
-    to.push_back(GetLeftChestTube()->Unload());
-  }
-  if (HasRightChestTube()) {
-    to.push_back(GetRightChestTube()->Unload());
-  }
-  if (HasConsciousRespiration()) {
-    to.push_back(GetConsciousRespiration()->Unload());
-  }
-  if (HasConsumeNutrients()) {
-    to.push_back(GetConsumeNutrients()->Unload());
-  }
-  if (HasEscharotomy()) {
-    for (auto itr : GetEscharotomies()) {
-      to.push_back(itr.second->Unload());
-    }
-  }
-  if (HasEbola()) {
-    to.push_back(GetEbola()->Unload());
-  }
-  if (HasExercise()) {
-    to.push_back(GetExercise()->Unload());
-  }
-  if (HasHemorrhage()) {
-    for (auto itr : GetHemorrhages()) {
-      to.push_back(itr.second->Unload());
-    }
-  }
-  if (HasInfection()) {
-    to.push_back(GetInfection()->Unload());
-  }
-  if (HasIntubation()) {
-    to.push_back(GetIntubation()->Unload());
-  }
-  if (HasMechanicalVentilation()) {
-    to.push_back(GetMechanicalVentilation()->Unload());
-  }
-  if (HasNasalCannula()) {
-    to.push_back(GetNasalCannula()->Unload());
-  }
-  if (HasLeftNeedleDecompression()) {
-    to.push_back(GetLeftNeedleDecompression()->Unload());
-  }
-  if (HasRightNeedleDecompression()) {
-    to.push_back(GetRightNeedleDecompression()->Unload());
-  }
-  if (HasPainStimulus()) {
-    for (auto itr : GetPainStimuli()) {
-      to.push_back(itr.second->Unload());
-    }
-  }
-  if (HasPericardialEffusion()) {
-    to.push_back(GetPericardialEffusion()->Unload());
-  }
-  if (HasPulmonaryShunt()) {
-    to.push_back(GetPulmonaryShunt()->Unload());
-  }
-  if (HasRadiationAbsorbedDose()) {
-    to.push_back(GetRadiationAbsorbedDose()->Unload());
-  }
-  if (HasSleepState()) {
-    to.push_back(GetSleepState()->Unload());
-  }
-  if (HasLeftClosedTensionPneumothorax()) {
-    to.push_back(GetLeftClosedTensionPneumothorax()->Unload());
-  }
-  if (HasLeftOpenTensionPneumothorax()) {
-    to.push_back(GetLeftOpenTensionPneumothorax()->Unload());
-  }
-  if (HasRightClosedTensionPneumothorax()) {
-    to.push_back(GetRightClosedTensionPneumothorax()->Unload());
-  }
-  if (HasRightOpenTensionPneumothorax()) {
-    to.push_back(GetRightOpenTensionPneumothorax()->Unload());
-  }
-  for (auto itr : GetSubstanceBoluses()) {
-    to.push_back(itr.second->Unload());
-  }
-  for (auto itr : GetSubstanceInfusions()) {
-    to.push_back(itr.second->Unload());
-  }
-  for (auto itr : GetSubstanceOralDoses()) {
-    to.push_back(itr.second->Unload());
-  }
-  for (auto itr : GetSubstanceCompoundInfusions()) {
-    to.push_back(itr.second->Unload());
-  }
-  if (HasTourniquet()) {
-    for (auto itr : GetTourniquets()) {
-      to.push_back(itr.second->Unload());
-    }
-  }
-  if (HasUrinate()) {
-    to.push_back(GetUrinate()->Unload());
-  }
-  if (HasOverride()) {
-    to.push_back((GetOverride()->Unload()));
-  }
+  DELETE_MAP_OF_POINTERS(m_Escharotomies);
+  DELETE_MAP_OF_POINTERS(m_Hemorrhages);
+  DELETE_MAP_OF_POINTERS(m_PainStimuli);
+  DELETE_MAP_OF_POINTERS(m_SubstanceBolus);
+  DELETE_MAP_OF_POINTERS(m_SubstanceInfusions);
+  DELETE_MAP_OF_POINTERS(m_SubstanceOralDoses);
+  DELETE_MAP_OF_POINTERS(m_SubstanceCompoundInfusions);
+  DELETE_MAP_OF_POINTERS(m_Tourniquets);
 }
 //-------------------------------------------------------------------------------
 bool SEPatientActionCollection::ProcessAction(const SEPatientAction& action, const PhysiologyEngine& engine)
@@ -725,23 +583,23 @@ bool SEPatientActionCollection::ProcessAction(const SEPatientAction& action, con
     }
   }
 
-  auto chestTube = dynamic_cast<const SEChestTube*>(&action);
-  if (chestTube != nullptr) {
-    if (chestTube->Side() == SESide::Left) {
+  auto chestTu = dynamic_cast<const SEChestTube*>(&action);
+  if (chestTu != nullptr) {
+    if (chestTu->GetSide() == SESide::Left) {
       if (m_LeftChestTube == nullptr) {
         m_LeftChestTube = new SEChestTube();
       }
-      m_LeftChestTube->Load(*chestTube);
+      CDM_PATIENT_ACTION_COPY(ChestTube, *chestTu, *m_LeftChestTube)
       if (!m_LeftChestTube->IsActive()) {
         RemoveLeftChestTube();
         return true;
       }
       return IsValid(*m_LeftChestTube);
-    } else if (chestTube->Side() == SESide::Right) {
+    } else if (chestTu->GetSide() == SESide::Right) {
       if (m_RightChestTube == nullptr) {
         m_RightChestTube = new SEChestTube();
       }
-      m_RightChestTube->Load(*chestTube);
+      CDM_PATIENT_ACTION_COPY(ChestTube, *chestTu, *m_RightChestTube)
       if (!m_RightChestTube->IsActive()) {
         RemoveRightChestTube();
         return true;

--- a/projects/biogears/libBiogears/src/engine/Systems/Nervous.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Nervous.cpp
@@ -311,7 +311,7 @@ void Nervous::CentralSignalProcess()
   const double xCO2SP = 0.25;
   const double tauIschemia = 30.0;
   const double tauCO2 = 20.0;
-
+  
 
   // Exercise Signal Modifiers
   double fExerciseSympathetic = 0.0;

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -169,13 +169,6 @@ void Respiratory::Initialize()
   m_TopBreathPleuralPressure_cmH2O = 0.0;
   m_LastCardiacCycleBloodPH = 7.4;
 
-  m_data.GetDataTrack().Probe("m_TopBreathTotalVolume_L ", m_TopBreathTotalVolume_L);
-  m_data.GetDataTrack().Probe("m_TopBreathAlveoliVolume_L ", m_TopBreathAlveoliVolume_L);
-  m_data.GetDataTrack().Probe("m_TopBreathDeadSpaceVolume_L ", m_TopBreathDeadSpaceVolume_L);
-  m_data.GetDataTrack().Probe("m_TopBreathPleuralPressure_cmH2O ", m_TopBreathPleuralPressure_cmH2O);
-  //m_data.GetDataTrack().Probe("m_OxygenAutoregulatorHeart ", m_OxygenAutoregulatorHeart);
-  //m_data.GetDataTrack().Probe("m_OxygenAutoregulatorMuscle ", m_OxygenAutoregulatorMuscle);
-
   //Driver
   //Basically a Y-shift for the driver
   m_DefaultDrivePressure_cmH2O = -5.0;
@@ -1565,24 +1558,38 @@ void Respiratory::DoLeftChestTube(double ctFlowResistance)
 ///
 ///
 /// \details
-/// Need a way to return pressure after a surgical proceedure
+/// Need a way to return pressure after a surgical proceedure. Since we don't consider the biomechanics 
+/// of the lungs expansion reducing the volume in the pleural space after chest tube, we will 
+/// manually move volume to ground as a result of the proceedure
 //--------------------------------------------------------------------------------------------------
 void Respiratory::AdjustPleuralCavity()
 {
-  if (!m_PatientActions->HasRightChestTube()) {
-    return;
+  if (m_PatientActions->HasRightChestTube()) {
+
+    double cavityPressure = m_RightPleuralCavity->GetPressure().GetValue(PressureUnit::cmH2O);
+
+    //lets reduce plueral pressure slowly
+    m_RightPleuralCavity->GetNextPressure().SetReadOnly(false);
+    m_RightPleuralCavity->GetNextVolume().SetReadOnly(false);
+
+    if (m_RightPleuralCavity->GetVolume().GetValue(VolumeUnit::mL) > 550.0) {
+      m_RightPleuralCavity->GetNextVolume().DecrementValue(0.01, VolumeUnit::mL);
+    }
   }
 
-  double cavityPressure = m_RightPleuralCavity->GetPressure().GetValue(PressureUnit::cmH2O);
+   if (m_PatientActions->HasLeftChestTube()) {
 
-  //lets reduce plueral pressure slowly
-  m_RightPleuralCavity->GetNextPressure().SetReadOnly(false);
-  m_RightPleuralCavity->GetNextVolume().SetReadOnly(false);
+    double cavityPressure = m_LeftPleuralCavity->GetPressure().GetValue(PressureUnit::cmH2O);
 
-  if (m_RightPleuralCavity->GetVolume().GetValue(VolumeUnit::mL) > 550.0) {
-    m_RightPleuralCavity->GetNextVolume().DecrementValue(0.01, VolumeUnit::mL);
+    //lets reduce plueral pressure slowly
+    m_LeftPleuralCavity->GetNextPressure().SetReadOnly(false);
+    m_LeftPleuralCavity->GetNextVolume().SetReadOnly(false);
+
+    if (m_LeftPleuralCavity->GetVolume().GetValue(VolumeUnit::mL) > 550.0) {
+      m_LeftPleuralCavity->GetNextVolume().DecrementValue(0.01, VolumeUnit::mL);
+    }
   }
- // m_LeftPleuralCavity->GetNextPressure().IncrementValue(-10.0, PressureUnit::cmH2O);
+
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1903,11 +1910,6 @@ void Respiratory::CalculateVitalSigns()
     m_TopBreathAlveoliVolume_L = m_RightAlveoli->GetNextVolume().GetValue(VolumeUnit::L) + m_LeftAlveoli->GetNextVolume().GetValue(VolumeUnit::L);
     m_TopBreathDeadSpaceVolume_L = m_RightBronchi->GetNextVolume().GetValue(VolumeUnit::L) + m_LeftBronchi->GetNextVolume().GetValue(VolumeUnit::L) + m_Trachea->GetVolume(VolumeUnit::L);
     m_TopBreathPleuralPressure_cmH2O = dPleuralPressure_cmH2O;
-
-    m_data.GetDataTrack().Probe("m_TopBreathTotalVolume_L ", m_TopBreathTotalVolume_L);
-    m_data.GetDataTrack().Probe("m_TopBreathAlveoliVolume_L ", m_TopBreathAlveoliVolume_L);
-    m_data.GetDataTrack().Probe("m_TopBreathDeadSpaceVolume_L ", m_TopBreathDeadSpaceVolume_L);
-    m_data.GetDataTrack().Probe("m_TopBreathPleuralPressure_cmH2O ", m_TopBreathPleuralPressure_cmH2O);
 
     if (m_data.GetState() > EngineState::InitialStabilization) { // Don't throw events if we are initializing
       //Check for acute lung injury and acute respiratory distress

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -1329,7 +1329,7 @@ void Respiratory::Pneumothorax()
         DoRightNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
       }
       if (m_PatientActions->HasRightChestTube()) {
-        DoRightNeedleDecompression(dChestTubeFlowResistance_cmH2O_s_Per_L);
+        DoRightChestTube(dChestTubeFlowResistance_cmH2O_s_Per_L);
       }
     }
 

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -102,6 +102,7 @@ void Respiratory::Invalidate()
   m_LeftLungExtravascular = nullptr;
   m_RightLungExtravascular = nullptr;
   m_Trachea = nullptr;
+  m_pleuralCavity = nullptr;
   m_AortaO2 = nullptr;
   m_AortaCO2 = nullptr;
   m_MechanicalVentilatorConnection = nullptr;
@@ -286,6 +287,7 @@ void Respiratory::SetUp()
   m_LeftLung = m_data.GetCompartments().GetGasCompartment(BGE::PulmonaryCompartment::LeftLung);
   m_RightLung = m_data.GetCompartments().GetGasCompartment(BGE::PulmonaryCompartment::RightLung);
   m_Lungs = m_data.GetCompartments().GetGasCompartment(BGE::PulmonaryCompartment::Lungs);
+  m_pleuralCavity = m_data.GetCompartments().GetGasCompartment(BGE::PulmonaryCompartment::PleuralCavity);
   m_LeftLungExtravascular = m_data.GetCompartments().GetLiquidCompartment(BGE::ExtravascularCompartment::LeftLungIntracellular);
   m_RightLungExtravascular = m_data.GetCompartments().GetLiquidCompartment(BGE::ExtravascularCompartment::RightLungIntracellular);
   m_Trachea = m_data.GetCompartments().GetGasCompartment(BGE::PulmonaryCompartment::Trachea);
@@ -440,7 +442,7 @@ void Respiratory::PreProcess()
   ConsciousRespiration();
   NasalCannula();
   MechanicalVentilation();
-
+  AdjustPleuralCavity();
   RespiratoryDriver();
 }
 
@@ -1486,6 +1488,24 @@ void Respiratory::ProcessConsciousRespiration(SEConsciousRespirationCommand& cmd
 
 //--------------------------------------------------------------------------------------------------
 /// \brief
+/// Right Side Needle Decompression
+///
+/// \param  dFlowResistance - Resistance value for air flow through the needle
+///
+/// \details
+/// Used for right side needle decompression. this is an intervention (action) used to treat right
+/// side tension pneumothorax
+//--------------------------------------------------------------------------------------------------
+void Respiratory::DoRightNeedleDecompression(double dFlowResistance)
+{
+  //Leak flow resistance that is scaled in proportion to Lung resistance, depending on severity
+  double dScalingFactor = 0.5; //Tuning parameter to allow gas flow due to needle decompression using lung resistance as reference
+  double dFlowResistanceRightNeedle = dScalingFactor * dFlowResistance;
+  m_RightPleuralCavityToEnvironment->GetNextResistance().SetValue(dFlowResistanceRightNeedle, FlowResistanceUnit::cmH2O_s_Per_L);
+}
+
+//--------------------------------------------------------------------------------------------------
+/// \brief
 /// Left Side Needle Decompression
 ///
 /// \param  dFlowResistance - Resistance value for air flow through the needle
@@ -1518,6 +1538,7 @@ void Respiratory::DoRightChestTube(double ctFlowResistance)
   double dScalingFactor = 0.5; //Tuning parameter to allow gas flow due to needle decompression using lung resistance as reference
   double dFlowResistanceRightNeedle = dScalingFactor * ctFlowResistance;
   m_RightPleuralCavityToEnvironment->GetNextResistance().SetValue(dFlowResistanceRightNeedle, FlowResistanceUnit::cmH2O_s_Per_L);
+
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1540,21 +1561,30 @@ void Respiratory::DoLeftChestTube(double ctFlowResistance)
 
 //--------------------------------------------------------------------------------------------------
 /// \brief
-/// Right Side Needle Decompression
+/// adjust pleural cavity pressure after injury
 ///
-/// \param  dFlowResistance - Resistance value for air flow through the needle
 ///
 /// \details
-/// Used for right side needle decompression. this is an intervention (action) used to treat right
-/// side tension pneumothorax
+/// Need a way to return pressure after a surgical proceedure
 //--------------------------------------------------------------------------------------------------
-void Respiratory::DoRightNeedleDecompression(double dFlowResistance)
+void Respiratory::AdjustPleuralCavity()
 {
-  //Leak flow resistance that is scaled in proportion to Lung resistance, depending on severity
-  double dScalingFactor = 0.5; //Tuning parameter to allow gas flow due to needle decompression using lung resistance as reference
-  double dFlowResistanceRightNeedle = dScalingFactor * dFlowResistance;
-  m_RightPleuralCavityToEnvironment->GetNextResistance().SetValue(dFlowResistanceRightNeedle, FlowResistanceUnit::cmH2O_s_Per_L);
+  if (!m_PatientActions->HasRightChestTube()) {
+    return;
+  }
+
+  double cavityPressure = m_RightPleuralCavity->GetPressure().GetValue(PressureUnit::cmH2O);
+
+  //lets reduce plueral pressure slowly
+  m_RightPleuralCavity->GetNextPressure().SetReadOnly(false);
+  m_RightPleuralCavity->GetNextVolume().SetReadOnly(false);
+
+  if (m_RightPleuralCavity->GetVolume().GetValue(VolumeUnit::mL) > 550.0) {
+    m_RightPleuralCavity->GetNextVolume().DecrementValue(0.01, VolumeUnit::mL);
+  }
+ // m_LeftPleuralCavity->GetNextPressure().IncrementValue(-10.0, PressureUnit::cmH2O);
 }
+
 //--------------------------------------------------------------------------------------------------
 /// \brief
 /// Pulmonary Shunt Implementation

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -1329,7 +1329,7 @@ void Respiratory::Pneumothorax()
         DoRightNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
       }
       if (m_PatientActions->HasRightChestTube()) {
-        DoRightNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
+        DoRightNeedleDecompression(dChestTubeFlowResistance_cmH2O_s_Per_L);
       }
     }
 

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -1249,7 +1249,7 @@ void Respiratory::Pneumothorax()
       double severity = m_PatientActions->GetLeftOpenTensionPneumothorax()->GetSeverity().GetValue();
       double resistance_cmH2O_s_Per_L = dPneumoMaxFlowResistance_cmH2O_s_Per_L;
       if (severity > 0.0 && !m_PatientActions->HasLeftChestOcclusiveDressing()) {
-        resistance_cmH2O_s_Per_L = dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
+        resistance_cmH2O_s_Per_L = -544.44 * severity + 554.44; //dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
       }
       resistance_cmH2O_s_Per_L = std::min(resistance_cmH2O_s_Per_L, dPneumoMaxFlowResistance_cmH2O_s_Per_L);
       m_EnvironmentToLeftChestLeak->GetNextResistance().SetValue(resistance_cmH2O_s_Per_L, FlowResistanceUnit::cmH2O_s_Per_L);
@@ -1266,7 +1266,7 @@ void Respiratory::Pneumothorax()
       double severity = m_PatientActions->GetRightOpenTensionPneumothorax()->GetSeverity().GetValue();
       double resistance_cmH2O_s_Per_L = dPneumoMaxFlowResistance_cmH2O_s_Per_L;
       if (severity > 0.0 && !m_PatientActions->HasRightChestOcclusiveDressing()) {
-        resistance_cmH2O_s_Per_L = dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
+        resistance_cmH2O_s_Per_L = -544.44 * severity + 554.44; //dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
       }
       resistance_cmH2O_s_Per_L = std::min(resistance_cmH2O_s_Per_L, dPneumoMaxFlowResistance_cmH2O_s_Per_L);
       m_EnvironmentToRightChestLeak->GetNextResistance().SetValue(resistance_cmH2O_s_Per_L, FlowResistanceUnit::cmH2O_s_Per_L);
@@ -1284,7 +1284,7 @@ void Respiratory::Pneumothorax()
       double severity = m_PatientActions->GetLeftClosedTensionPneumothorax()->GetSeverity().GetValue();
       double resistance_cmH2O_s_Per_L = dPneumoMaxFlowResistance_cmH2O_s_Per_L;
       if (severity > 0.0) {
-        resistance_cmH2O_s_Per_L = dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
+        resistance_cmH2O_s_Per_L = -544.44 * severity + 554.44; //dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
       }
       resistance_cmH2O_s_Per_L = std::min(resistance_cmH2O_s_Per_L, dPneumoMaxFlowResistance_cmH2O_s_Per_L);
       m_LeftAlveoliLeakToLeftPleuralCavity->GetNextResistance().SetValue(resistance_cmH2O_s_Per_L, FlowResistanceUnit::cmH2O_s_Per_L);
@@ -1302,7 +1302,7 @@ void Respiratory::Pneumothorax()
       double severity = m_PatientActions->GetRightClosedTensionPneumothorax()->GetSeverity().GetValue();
       double resistance_cmH2O_s_Per_L = dPneumoMaxFlowResistance_cmH2O_s_Per_L;
       if (severity > 0.0) {
-        resistance_cmH2O_s_Per_L = dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
+        resistance_cmH2O_s_Per_L = -544.44 * severity + 554.44; //dPneumoMinFlowResistance_cmH2O_s_Per_L / std::pow(severity, 2.0);
       }
       resistance_cmH2O_s_Per_L = std::min(resistance_cmH2O_s_Per_L, dPneumoMaxFlowResistance_cmH2O_s_Per_L);
       m_RightAlveoliLeakToRightPleuralCavity->GetNextResistance().SetValue(resistance_cmH2O_s_Per_L, FlowResistanceUnit::cmH2O_s_Per_L);

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -1235,6 +1235,8 @@ void Respiratory::Pneumothorax()
     double dPneumoMaxFlowResistance_cmH2O_s_Per_L = m_dDefaultOpenResistance_cmH2O_s_Per_L;
     // Flow resistance for the decompression needle, if used
     double dNeedleFlowResistance_cmH2O_s_Per_L = 15.0/13.0;
+    // Flow resistance for the chest tube, if used
+    double dChestTubeFlowResistance_cmH2O_s_Per_L = 15.0;
     // Increase in pleural pressure restricts blood return to heart.  Model this by increasing vena cava->right heart resistance
     SEFluidCircuitPath* venousReturn = m_data.GetCircuits().GetCardiovascularCircuit().GetPath(BGE::CardiovascularPath::VenaCavaToRightAtrium1);
     double nextVenousResistance = venousReturn->GetResistanceBaseline(FlowResistanceUnit::mmHg_s_Per_mL);
@@ -1259,6 +1261,9 @@ void Respiratory::Pneumothorax()
       if (m_PatientActions->HasLeftNeedleDecompression()) {
         DoLeftNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
       }
+      if (m_PatientActions->HasLeftChestTube()) {
+        DoLeftChestTube(dChestTubeFlowResistance_cmH2O_s_Per_L);
+      }
     }
 
     if (m_PatientActions->HasRightOpenTensionPneumothorax()) {
@@ -1277,6 +1282,11 @@ void Respiratory::Pneumothorax()
       if (m_PatientActions->HasRightNeedleDecompression()) {
         DoRightNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
       }
+
+      if (m_PatientActions->HasRightChestTube()) {
+        DoRightChestTube(dChestTubeFlowResistance_cmH2O_s_Per_L);
+      }
+
     }
 
     if (m_PatientActions->HasLeftClosedTensionPneumothorax()) {
@@ -1295,6 +1305,11 @@ void Respiratory::Pneumothorax()
       if (m_PatientActions->HasLeftNeedleDecompression()) {
         DoLeftNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
       }
+
+      if (m_PatientActions->HasLeftChestTube()) {
+        DoLeftChestTube(dChestTubeFlowResistance_cmH2O_s_Per_L);
+      }
+
     }
 
     if (m_PatientActions->HasRightClosedTensionPneumothorax()) {
@@ -1313,24 +1328,29 @@ void Respiratory::Pneumothorax()
       if (m_PatientActions->HasRightNeedleDecompression()) {
         DoRightNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
       }
+      if (m_PatientActions->HasRightChestTube()) {
+        DoRightNeedleDecompression(dNeedleFlowResistance_cmH2O_s_Per_L);
+      }
     }
 
     //Check for interventions without insult
     if (!m_PatientActions->HasLeftClosedTensionPneumothorax() && !m_PatientActions->HasLeftOpenTensionPneumothorax()) {
-      if (m_PatientActions->HasLeftChestOcclusiveDressing() || m_PatientActions->HasLeftNeedleDecompression()) {
+      if (m_PatientActions->HasLeftChestOcclusiveDressing() || m_PatientActions->HasLeftNeedleDecompression() || m_PatientActions->HasLeftChestTube()) {
         /// \error Patient: Cannot perform an intervention if Tension Pneumothorax is not present on that side.
         Error("Cannot perform an intervention if Tension Pneumothorax is not present on that side.");
         m_PatientActions->RemoveLeftChestOcclusiveDressing();
         m_PatientActions->RemoveLeftNeedleDecompression();
+        m_PatientActions->RemoveLeftChestTube();
         return;
       }
     }
     if (!m_PatientActions->HasRightClosedTensionPneumothorax() && !m_PatientActions->HasRightOpenTensionPneumothorax()) {
-      if (m_PatientActions->HasRightChestOcclusiveDressing() || m_PatientActions->HasRightNeedleDecompression()) {
+      if (m_PatientActions->HasRightChestOcclusiveDressing() || m_PatientActions->HasRightNeedleDecompression() || m_PatientActions->HasRightChestTube()) {
         /// \error Patient: Cannot perform an intervention if Tension Pneumothorax is not present on that side.
         Error("Cannot perform an intervention if Tension Pneumothorax is not present on that side.");
         m_PatientActions->RemoveRightChestOcclusiveDressing();
         m_PatientActions->RemoveRightNeedleDecompression();
+        m_PatientActions->RemoveRightChestTube();
         return;
       }
     }
@@ -1349,6 +1369,13 @@ void Respiratory::Pneumothorax()
       Error("Cannot perform a Chest Occlusive Dressing intervention if Tension Pneumothorax is not present");
       m_PatientActions->RemoveLeftChestOcclusiveDressing();
       m_PatientActions->RemoveRightChestOcclusiveDressing();
+      return;
+    }
+    if (m_PatientActions->HasChestTube()) {
+      /// \error Patient: can't process a chest occlusive dressing if no pneumothorax is present
+      Error("Cannot perform a Chest Tube intervention if Tension Pneumothorax is not present");
+      m_PatientActions->RemoveLeftChestTube();
+      m_PatientActions->RemoveRightChestTube();
       return;
     }
   }
@@ -1477,6 +1504,42 @@ void Respiratory::DoLeftNeedleDecompression(double dFlowResistance)
 /// Used for right side needle decompression. this is an intervention (action) used to treat right
 /// side tension pneumothorax
 //--------------------------------------------------------------------------------------------------
+void Respiratory::DoRightChestTube(double ctFlowResistance)
+{
+  //Leak flow resistance that is scaled in proportion to Lung resistance, depending on severity
+  double dScalingFactor = 0.5; //Tuning parameter to allow gas flow due to needle decompression using lung resistance as reference
+  double dFlowResistanceRightNeedle = dScalingFactor * ctFlowResistance;
+  m_RightPleuralCavityToEnvironment->GetNextResistance().SetValue(dFlowResistanceRightNeedle, FlowResistanceUnit::cmH2O_s_Per_L);
+}
+
+//--------------------------------------------------------------------------------------------------
+/// \brief
+/// Left Side Needle Decompression
+///
+/// \param  dFlowResistance - Resistance value for air flow through the needle
+///
+/// \details
+/// Used for left side needle decompression. this is an intervention (action) used to treat left
+/// side tension pneumothorax
+//--------------------------------------------------------------------------------------------------
+void Respiratory::DoLeftChestTube(double ctFlowResistance)
+{
+  //Leak flow resistance that is scaled in proportion to Lung resistance, depending on severity
+  double dScalingFactor = 0.5; //Tuning parameter to allow gas flow due to needle decompression using lung resistance as reference
+  double dFlowResistanceLeftNeedle = dScalingFactor * ctFlowResistance;
+  m_LeftPleuralCavityToEnvironment->GetNextResistance().SetValue(dFlowResistanceLeftNeedle, FlowResistanceUnit::cmH2O_s_Per_L);
+}
+
+//--------------------------------------------------------------------------------------------------
+/// \brief
+/// Right Side Needle Decompression
+///
+/// \param  dFlowResistance - Resistance value for air flow through the needle
+///
+/// \details
+/// Used for right side needle decompression. this is an intervention (action) used to treat right
+/// side tension pneumothorax
+//--------------------------------------------------------------------------------------------------
 void Respiratory::DoRightNeedleDecompression(double dFlowResistance)
 {
   //Leak flow resistance that is scaled in proportion to Lung resistance, depending on severity
@@ -1484,7 +1547,6 @@ void Respiratory::DoRightNeedleDecompression(double dFlowResistance)
   double dFlowResistanceRightNeedle = dScalingFactor * dFlowResistance;
   m_RightPleuralCavityToEnvironment->GetNextResistance().SetValue(dFlowResistanceRightNeedle, FlowResistanceUnit::cmH2O_s_Per_L);
 }
-
 //--------------------------------------------------------------------------------------------------
 /// \brief
 /// Pulmonary Shunt Implementation

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -168,6 +168,13 @@ void Respiratory::Initialize()
   m_TopBreathPleuralPressure_cmH2O = 0.0;
   m_LastCardiacCycleBloodPH = 7.4;
 
+  m_data.GetDataTrack().Probe("m_TopBreathTotalVolume_L ", m_TopBreathTotalVolume_L);
+  m_data.GetDataTrack().Probe("m_TopBreathAlveoliVolume_L ", m_TopBreathAlveoliVolume_L);
+  m_data.GetDataTrack().Probe("m_TopBreathDeadSpaceVolume_L ", m_TopBreathDeadSpaceVolume_L);
+  m_data.GetDataTrack().Probe("m_TopBreathPleuralPressure_cmH2O ", m_TopBreathPleuralPressure_cmH2O);
+  //m_data.GetDataTrack().Probe("m_OxygenAutoregulatorHeart ", m_OxygenAutoregulatorHeart);
+  //m_data.GetDataTrack().Probe("m_OxygenAutoregulatorMuscle ", m_OxygenAutoregulatorMuscle);
+
   //Driver
   //Basically a Y-shift for the driver
   m_DefaultDrivePressure_cmH2O = -5.0;
@@ -179,6 +186,7 @@ void Respiratory::Initialize()
   m_VentilationFrequency_Per_min = m_Patient->GetRespirationRateBaseline(FrequencyUnit::Per_min);
   m_DriverPressure_cmH2O = m_DefaultDrivePressure_cmH2O;
   m_DriverPressureMin_cmH2O = m_DefaultDrivePressure_cmH2O;
+
 
   //The peak driver pressure is the pressure above the default pressure
   m_PeakRespiratoryDrivePressure_cmH2O = m_Patient->GetRespiratoryDriverAmplitudeBaseline(PressureUnit::cmH2O);
@@ -1860,10 +1868,16 @@ void Respiratory::CalculateVitalSigns()
     m_Patient->SetEvent(SEPatientEventType::StartOfExhale, true, m_data.GetSimulationTime());
     m_BreathTimeExhale_min = m_ElapsedBreathingCycleTime_min;
     m_BreathingCycle = true;
+    
     m_TopBreathTotalVolume_L = GetTotalLungVolume(VolumeUnit::L);
     m_TopBreathAlveoliVolume_L = m_RightAlveoli->GetNextVolume().GetValue(VolumeUnit::L) + m_LeftAlveoli->GetNextVolume().GetValue(VolumeUnit::L);
     m_TopBreathDeadSpaceVolume_L = m_RightBronchi->GetNextVolume().GetValue(VolumeUnit::L) + m_LeftBronchi->GetNextVolume().GetValue(VolumeUnit::L) + m_Trachea->GetVolume(VolumeUnit::L);
     m_TopBreathPleuralPressure_cmH2O = dPleuralPressure_cmH2O;
+
+    m_data.GetDataTrack().Probe("m_TopBreathTotalVolume_L ", m_TopBreathTotalVolume_L);
+    m_data.GetDataTrack().Probe("m_TopBreathAlveoliVolume_L ", m_TopBreathAlveoliVolume_L);
+    m_data.GetDataTrack().Probe("m_TopBreathDeadSpaceVolume_L ", m_TopBreathDeadSpaceVolume_L);
+    m_data.GetDataTrack().Probe("m_TopBreathPleuralPressure_cmH2O ", m_TopBreathPleuralPressure_cmH2O);
 
     if (m_data.GetState() > EngineState::InitialStabilization) { // Don't throw events if we are initializing
       //Check for acute lung injury and acute respiratory distress

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -1234,14 +1234,14 @@ void Respiratory::Pneumothorax()
     // Maximum flow resistance for the chest cavity or alveoli leak
     double dPneumoMaxFlowResistance_cmH2O_s_Per_L = m_dDefaultOpenResistance_cmH2O_s_Per_L;
     // Flow resistance for the decompression needle, if used
-    double dNeedleFlowResistance_cmH2O_s_Per_L = 15.0;
+    double dNeedleFlowResistance_cmH2O_s_Per_L = 15.0/13.0;
     // Increase in pleural pressure restricts blood return to heart.  Model this by increasing vena cava->right heart resistance
     SEFluidCircuitPath* venousReturn = m_data.GetCircuits().GetCardiovascularCircuit().GetPath(BGE::CardiovascularPath::VenaCavaToRightAtrium1);
     double nextVenousResistance = venousReturn->GetResistanceBaseline(FlowResistanceUnit::mmHg_s_Per_mL);
     double normalPleuralPressure_mmHg = -4.2;
     double venousResistanceModifier = GeneralMath::LinearInterpolator(normalPleuralPressure_mmHg, 3.0, 1.0, 4.0, GetMeanPleuralPressure(PressureUnit::mmHg));
     venousResistanceModifier = std::max(1.0, venousResistanceModifier);
-    nextVenousResistance *= venousResistanceModifier;
+    nextVenousResistance *= 1.1*venousResistanceModifier;
     venousReturn->GetNextResistance().SetValue(nextVenousResistance, FlowResistanceUnit::mmHg_s_Per_mL);
 
     if (m_PatientActions->HasLeftOpenTensionPneumothorax()) {

--- a/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
+++ b/projects/biogears/libBiogears/src/engine/Systems/Respiratory.cpp
@@ -1246,7 +1246,7 @@ void Respiratory::Pneumothorax()
     double normalPleuralPressure_mmHg = -4.2;
     double venousResistanceModifier = GeneralMath::LinearInterpolator(normalPleuralPressure_mmHg, 3.0, 1.0, 4.0, GetMeanPleuralPressure(PressureUnit::mmHg));
     venousResistanceModifier = std::max(1.0, venousResistanceModifier);
-    nextVenousResistance *= 1.1*venousResistanceModifier;
+    nextVenousResistance *= 2.1*venousResistanceModifier;
     venousReturn->GetNextResistance().SetValue(nextVenousResistance, FlowResistanceUnit::mmHg_s_Per_mL);
 
     if (m_PatientActions->HasLeftOpenTensionPneumothorax()) {
@@ -1573,7 +1573,7 @@ void Respiratory::AdjustPleuralCavity()
     m_RightPleuralCavity->GetNextVolume().SetReadOnly(false);
 
     if (m_RightPleuralCavity->GetVolume().GetValue(VolumeUnit::mL) > 550.0) {
-      m_RightPleuralCavity->GetNextVolume().DecrementValue(0.01, VolumeUnit::mL);
+      m_RightPleuralCavity->GetNextVolume().DecrementValue(0.1, VolumeUnit::mL);
     }
   }
 
@@ -1586,7 +1586,7 @@ void Respiratory::AdjustPleuralCavity()
     m_LeftPleuralCavity->GetNextVolume().SetReadOnly(false);
 
     if (m_LeftPleuralCavity->GetVolume().GetValue(VolumeUnit::mL) > 550.0) {
-      m_LeftPleuralCavity->GetNextVolume().DecrementValue(0.01, VolumeUnit::mL);
+      m_LeftPleuralCavity->GetNextVolume().DecrementValue(0.1, VolumeUnit::mL);
     }
   }
 

--- a/projects/biogears/libBiogears/src/io/cdm/PatientActions.cpp
+++ b/projects/biogears/libBiogears/src/io/cdm/PatientActions.cpp
@@ -33,6 +33,7 @@
 #include <biogears/cdm/patient/actions/SEChestCompressionForce.h>
 #include <biogears/cdm/patient/actions/SEChestCompressionForceScale.h>
 #include <biogears/cdm/patient/actions/SEChestOcclusiveDressing.h>
+#include <biogears/cdm/patient/actions/SEChestTube.h>
 #include <biogears/cdm/patient/actions/SEConsciousRespiration.h>
 #include <biogears/cdm/patient/actions/SEConsciousRespirationCommand.h>
 #include <biogears/cdm/patient/actions/SEConsumeNutrients.h>
@@ -170,6 +171,60 @@ namespace io {
         auto substance = substances.GetSubstance(substanceOralDoseData->Substance());
         if (substance == nullptr) {
           throw biogears::CommonDataModelException("PatientActions:Factory - Unknown substance : " + substanceOralDoseData->Substance());
+      POLYMORPHIC_UNMARSHALL(environmentActionData, ThermalApplication, EnvironmentActions)
+
+      throw biogears::CommonDataModelException("PatientActions::factory: Unsupported Environment Action.");
+    }
+
+    if (auto patientActionData = dynamic_cast<CDM::PatientActionData const*>(actionData); patientActionData) {
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AcuteStress, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AcuteRespiratoryDistress, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AsthmaAttack, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AirwayObstruction, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Apnea, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, BrainInjury, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Bronchoconstriction, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, BurnWound, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, CardiacArrest, PatientActions, rd)
+
+      if (auto chestCompressionData = dynamic_cast<CDM::ChestCompressionData const*>(actionData); chestCompressionData) {
+        STOCASTIC_POLYMORPHIC_UNMARSHALL(chestCompressionData, ChestCompressionForce, PatientActions, rd)
+        STOCASTIC_POLYMORPHIC_UNMARSHALL(chestCompressionData, ChestCompressionForceScale, PatientActions, rd)
+        throw biogears::CommonDataModelException("PatientActions:Factory - Unsupported ChestCompression Action Received.");
+      }
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ChestOcclusiveDressing, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ChestTube, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ConsciousRespiration, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ConsumeNutrients, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Exercise, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Ebola, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Escharotomy, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ExampleAction, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Intubation, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Infection, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Hemorrhage, PatientActions, rd)
+      POLYMORPHIC_UNMARSHALL(patientActionData, MechanicalVentilation, PatientActions)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, NasalCannula, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, NeedleDecompression, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Override, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PainStimulus, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PatientAssessmentRequest, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PericardialEffusion, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PulmonaryShunt, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, RadiationAbsorbedDose, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, TensionPneumothorax, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Tourniquet, PatientActions, rd)
+      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Sleep, PatientActions, rd)
+
+      if (auto substanceAdministrationActionData = dynamic_cast<CDM::SubstanceAdministrationData const*>(actionData); substanceAdministrationActionData) {
+        if (auto substanceBolusData = dynamic_cast<CDM::SubstanceBolusData const*>(substanceAdministrationActionData); substanceBolusData) {
+          auto substance = substances.GetSubstance(substanceBolusData->Substance());
+          if (substance == nullptr) {
+            throw biogears::CommonDataModelException("PatientActions:Factory - Unknown substance : " + substanceBolusData->Substance());
+          }
+          auto substanceBolusaction = std::make_unique<SESubstanceBolus>(*substance);
+          PatientActions::UnMarshall(*substanceBolusData, *substanceBolusaction, rd);
+          return substanceBolusaction;
         }
         auto od = std::make_unique<SESubstanceOralDose>(*substance);
         PatientActions::UnMarshall(*substanceOralDoseData, *od, rd);
@@ -234,6 +289,7 @@ namespace io {
     POLYMORPHIC_MARSHALL(patientAction, ChestCompressionForce)
     POLYMORPHIC_MARSHALL(patientAction, ChestCompressionForceScale)
     POLYMORPHIC_MARSHALL(patientAction, ChestOcclusiveDressing)
+    POLYMORPHIC_MARSHALL(patientAction, ChestTube)
     POLYMORPHIC_MARSHALL(patientAction, Ebola)
     POLYMORPHIC_MARSHALL(patientAction, Escharotomy)
     POLYMORPHIC_MARSHALL(patientAction, ConsciousRespiration)
@@ -803,6 +859,25 @@ namespace io {
       PatientActions::Marshall(*cmd, *cmdData);
       out.Command().push_back(std::move(cmdData));
     }
+  }
+  //----------------------------------------------------------------------------------
+  // class SEChestTube
+  void PatientActions::UnMarshall(const CDM::ChestTubeData& in, SEChestTube& out, std::default_random_engine* rd)
+  {
+    out.Clear();
+
+    PatientActions::UnMarshall(static_cast<const CDM::PatientActionData&>(in), static_cast<SEPatientAction&>(out));
+    ;
+    Property::UnMarshall(in.Side(), out.m_Side);
+    Property::UnMarshall(in.State(), out.m_State);
+  }
+  void PatientActions::Marshall(const SEChestTube& in, CDM::ChestTubeData& out)
+  {
+    PatientActions::Marshall(static_cast<const SEPatientAction&>(in), static_cast<CDM::PatientActionData&>(out));
+    out.State(std::make_unique<std::remove_reference<decltype(out.State())>::type>());
+    Property::Marshall(in.m_State, out.State());
+
+    SE_PROPERTY_ENUM_MARSHALL_HELPER(in, out, Side)
   }
   //----------------------------------------------------------------------------------
   // class SEConsumeNutrients

--- a/projects/biogears/libBiogears/src/io/cdm/PatientActions.cpp
+++ b/projects/biogears/libBiogears/src/io/cdm/PatientActions.cpp
@@ -134,6 +134,7 @@ namespace io {
       throw biogears::CommonDataModelException("PatientActions:Factory - Unsupported ChestCompression Action Received.");
     }
     STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ChestOcclusiveDressing, PatientActions, rd)
+    STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ChestTube, PatientActions, rd)
     STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ConsciousRespiration, PatientActions, rd)
     STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ConsumeNutrients, PatientActions, rd)
     STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Exercise, PatientActions, rd)
@@ -171,60 +172,6 @@ namespace io {
         auto substance = substances.GetSubstance(substanceOralDoseData->Substance());
         if (substance == nullptr) {
           throw biogears::CommonDataModelException("PatientActions:Factory - Unknown substance : " + substanceOralDoseData->Substance());
-      POLYMORPHIC_UNMARSHALL(environmentActionData, ThermalApplication, EnvironmentActions)
-
-      throw biogears::CommonDataModelException("PatientActions::factory: Unsupported Environment Action.");
-    }
-
-    if (auto patientActionData = dynamic_cast<CDM::PatientActionData const*>(actionData); patientActionData) {
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AcuteStress, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AcuteRespiratoryDistress, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AsthmaAttack, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, AirwayObstruction, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Apnea, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, BrainInjury, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Bronchoconstriction, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, BurnWound, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, CardiacArrest, PatientActions, rd)
-
-      if (auto chestCompressionData = dynamic_cast<CDM::ChestCompressionData const*>(actionData); chestCompressionData) {
-        STOCASTIC_POLYMORPHIC_UNMARSHALL(chestCompressionData, ChestCompressionForce, PatientActions, rd)
-        STOCASTIC_POLYMORPHIC_UNMARSHALL(chestCompressionData, ChestCompressionForceScale, PatientActions, rd)
-        throw biogears::CommonDataModelException("PatientActions:Factory - Unsupported ChestCompression Action Received.");
-      }
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ChestOcclusiveDressing, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ChestTube, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ConsciousRespiration, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ConsumeNutrients, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Exercise, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Ebola, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Escharotomy, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, ExampleAction, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Intubation, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Infection, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Hemorrhage, PatientActions, rd)
-      POLYMORPHIC_UNMARSHALL(patientActionData, MechanicalVentilation, PatientActions)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, NasalCannula, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, NeedleDecompression, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Override, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PainStimulus, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PatientAssessmentRequest, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PericardialEffusion, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, PulmonaryShunt, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, RadiationAbsorbedDose, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, TensionPneumothorax, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Tourniquet, PatientActions, rd)
-      STOCASTIC_POLYMORPHIC_UNMARSHALL(patientActionData, Sleep, PatientActions, rd)
-
-      if (auto substanceAdministrationActionData = dynamic_cast<CDM::SubstanceAdministrationData const*>(actionData); substanceAdministrationActionData) {
-        if (auto substanceBolusData = dynamic_cast<CDM::SubstanceBolusData const*>(substanceAdministrationActionData); substanceBolusData) {
-          auto substance = substances.GetSubstance(substanceBolusData->Substance());
-          if (substance == nullptr) {
-            throw biogears::CommonDataModelException("PatientActions:Factory - Unknown substance : " + substanceBolusData->Substance());
-          }
-          auto substanceBolusaction = std::make_unique<SESubstanceBolus>(*substance);
-          PatientActions::UnMarshall(*substanceBolusData, *substanceBolusaction, rd);
-          return substanceBolusaction;
         }
         auto od = std::make_unique<SESubstanceOralDose>(*substance);
         PatientActions::UnMarshall(*substanceOralDoseData, *od, rd);
@@ -362,6 +309,12 @@ namespace io {
     }
     if (in.m_RightChestOcclusiveDressing) {
       out.push_back(PatientActions::factory(in.m_RightChestOcclusiveDressing));
+    }
+    if (in.m_LeftChestTube) {
+      out.push_back(PatientActions::factory(in.m_LeftChestTube));
+    }
+    if (in.m_RightChestTube) {
+      out.push_back(PatientActions::factory(in.m_RightChestTube));
     }
     if (in.m_ConsciousRespiration) {
       out.push_back(PatientActions::factory(in.m_ConsciousRespiration));
@@ -712,6 +665,25 @@ namespace io {
     SE_PROPERTY_ENUM_PTR_MARSHALL_HELPER(in, out, Side)
   }
   //----------------------------------------------------------------------------------
+  // class SEChestTube
+  void PatientActions::UnMarshall(const CDM::ChestTubeData& in, SEChestTube& out, std::default_random_engine* rd)
+  {
+    out.Invalidate();
+
+    PatientActions::UnMarshall(static_cast<const CDM::PatientActionData&>(in), static_cast<SEPatientAction&>(out));
+    ;
+    Property::UnMarshall(in.Side(), out.m_Side);
+    Property::UnMarshall(in.State(), out.m_State);
+  }
+  void PatientActions::Marshall(const SEChestTube& in, CDM::ChestTubeData& out)
+  {
+    PatientActions::Marshall(static_cast<const SEPatientAction&>(in), static_cast<CDM::PatientActionData&>(out));
+    out.State(std::make_unique<std::remove_reference<decltype(out.State())>::type>());
+    Property::Marshall(in.m_State, out.State());
+
+    SE_PROPERTY_ENUM_PTR_MARSHALL_HELPER(in, out, Side)
+  }
+  //----------------------------------------------------------------------------------
   // class SEConsciousRespirationCommand
   void PatientActions::UnMarshall(const CDM::ConsciousRespirationCommandData& in, SEConsciousRespirationCommand& out)
   {
@@ -859,25 +831,6 @@ namespace io {
       PatientActions::Marshall(*cmd, *cmdData);
       out.Command().push_back(std::move(cmdData));
     }
-  }
-  //----------------------------------------------------------------------------------
-  // class SEChestTube
-  void PatientActions::UnMarshall(const CDM::ChestTubeData& in, SEChestTube& out, std::default_random_engine* rd)
-  {
-    out.Clear();
-
-    PatientActions::UnMarshall(static_cast<const CDM::PatientActionData&>(in), static_cast<SEPatientAction&>(out));
-    ;
-    Property::UnMarshall(in.Side(), out.m_Side);
-    Property::UnMarshall(in.State(), out.m_State);
-  }
-  void PatientActions::Marshall(const SEChestTube& in, CDM::ChestTubeData& out)
-  {
-    PatientActions::Marshall(static_cast<const SEPatientAction&>(in), static_cast<CDM::PatientActionData&>(out));
-    out.State(std::make_unique<std::remove_reference<decltype(out.State())>::type>());
-    Property::Marshall(in.m_State, out.State());
-
-    SE_PROPERTY_ENUM_MARSHALL_HELPER(in, out, Side)
   }
   //----------------------------------------------------------------------------------
   // class SEConsumeNutrients

--- a/projects/biogears/libBiogears/src/io/cdm/PatientActions.h
+++ b/projects/biogears/libBiogears/src/io/cdm/PatientActions.h
@@ -70,6 +70,7 @@ class SEChestCompression;
 class SEChestCompressionForce;
 class SEChestCompressionForceScale;
 class SEChestOcclusiveDressing;
+class SEChestTube;
 class SEConsciousRespirationCommand;
 class SEEbola;
 class SEEscharotomy;
@@ -167,6 +168,9 @@ namespace io {
     // class SEChestCompressionForceScale;
     static void UnMarshall(const CDM::ChestCompressionForceScaleData& in, SEChestCompressionForceScale& out, std::default_random_engine* rd = nullptr);
     static void Marshall(const SEChestCompressionForceScale& in, CDM::ChestCompressionForceScaleData& out);
+    // class SENeedleDecompression;
+    static void UnMarshall(const CDM::ChestTubeData& in, SEChestTube& out, std::default_random_engine* rd = nullptr);
+    static void Marshall(const SEChestTube& in, CDM::ChestTubeData& out);
     // class SEChestOcclusiveDressing;
     static void UnMarshall(const CDM::ChestOcclusiveDressingData& in, SEChestOcclusiveDressing& out, std::default_random_engine* rd = nullptr);
     static void Marshall(const SEChestOcclusiveDressing& in, CDM::ChestOcclusiveDressingData& out);

--- a/share/xsd/cdm/PatientActions.xsd
+++ b/share/xsd/cdm/PatientActions.xsd
@@ -234,6 +234,18 @@ specific language governing permissions and limitations under the License.
     </xs:complexContent>
   </xs:complexType>
 
+  <!-- @brief A ChestTube. -->
+  <xs:complexType name="ChestTubeData">
+    <xs:complexContent>
+      <xs:extension base="PatientActionData">
+        <xs:attribute name="State" type="enumOnOff" use="required"/>
+        <!--<< @brief -->
+        <xs:attribute name="Side" type="enumSide" use="required"/>
+        <!--<< @brief -->
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
   <!-- @brief Base class of all concious breathing controls. -->
   <xs:complexType name="ConsciousRespirationCommandData" >
     <xs:complexContent>


### PR DESCRIPTION

[validation.zip](https://github.com/user-attachments/files/17741093/validation.zip)

adding the validation data, just changes to the pneumothorax and adding a chesttube action 

basic idea is that the needle decompression was "too performant" so basically the resistance to ground was much to high, resulting in unrealistic behavior for the intervention. 
- Increased needle path resistance
- added chest tube that opened up the path more 
- added a routine to remove excess volume in the pleural space in order to get recovery consistent with a chest tube 
- adjusted the pneumo severity to be linear, basically the nonlinear severity selected almost all actions to behave the same way (at the same rate), there is a bit more variability in the response across severity values now.
- No states included, happy to generate theme but figured you all would be managing states on your end
