### PR TITLE
abaird-adding support for gcc 11 on the ubuntu 22.04 distros, 

### DIFF
--- a/cmake/toolchains/aarch64-linux-gnu-gcc-10
+++ b/cmake/toolchains/aarch64-linux-gnu-gcc-10
@@ -1,0 +1,12 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR "armv8-a")
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc-10)
+set(CMAKE_C_FLAGS "-march=armv8-a+simd  --std=c20 -fPIC")
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++-10)
+set(CMAKE_CXX_FLAGS "-march=armv8-a+simd  --std=c++20 -fPIC")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/cmake/toolchains/x86_64-linux-gnu-gcc-11
+++ b/cmake/toolchains/x86_64-linux-gnu-gcc-11
@@ -1,0 +1,8 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER gcc-11)
+set(CMAKE_C_FLAGS "-mtune=core2 -std=c20 -fPIC")
+set(CMAKE_CXX_COMPILER g++-11)
+set(CMAKE_CXX_FLAGS "-mtune=core2 -std=c++20 -fPIC")


### PR DESCRIPTION
gcc 10 (I think) is the default for new debian arch

Some mild sleuthing made me thing that aarch file will work with new debian, I can test once we get this in on my build machine